### PR TITLE
Include total spaces and percent full in parking availability api

### DIFF
--- a/src/ParkingSpaces.py
+++ b/src/ParkingSpaces.py
@@ -15,10 +15,15 @@ class ParkingSpaces:
     table = soup.find_all('table', {"class": "AvailabilityTable"})[0]
     all_tr = table.find_all('tr')
 
-    # We don't want to fetch prices for all parking spots
-    exclude_locs = set(['Fullerton Free Church'])
+    # We don't want to fetch prices for all parking structures
+    exclude_locs = set(['Fullerton Free Church', 'S8 and S10'])
 
-    parking_dict = {}
+    parking_dict = {
+      'Nutwood Structure': {'available': None, 'total': 2504, 'perc_full': None},
+      'State College Structure': {'available': None, 'total': 1373, 'perc_full': None},
+      'Eastside North': {'available': None, 'total': 1880, 'perc_full': None},
+      'Eastside South': {'available': None, 'total': 1242, 'perc_full': None},
+    }
     # Iterate through rows in table
     for tr in all_tr:
       # Get parking structure name
@@ -41,8 +46,9 @@ class ParkingSpaces:
       avail_count = int(avail_count)
 
       # Valid parking spot if this point is reached
-      parking_dict[struct_name] = avail_count
-    
+      parking_dict[struct_name]['available'] = avail_count
+      parking_dict[struct_name]['perc_full'] = round(1 - (avail_count / parking_dict[struct_name]['total']), 2)
+
     return parking_dict
 
 if __name__ == "__main__":


### PR DESCRIPTION
I updated the parking availability api to include total parking spaces and percent full for each parking structure. We can use the percent full when calculating the price so higher percentages would mean higher prices.

```json
{
  "Nutwood Structure": {
    "available": 2024,
    "total": 2504,
    "perc_full": 0.19
  },
  "State College Structure": {
    "available": 1028,
    "total": 1373,
    "perc_full": 0.25
  },
  "Eastside North": {
    "available": 1465,
    "total": 1880,
    "perc_full": 0.22
  },
  "Eastside South": {
    "available": 853,
    "total": 1242,
    "perc_full": 0.31
  }
}
```