### PR TITLE
Add HTTPS to Nginx server

### DIFF
--- a/server/titanpark.nginx
+++ b/server/titanpark.nginx
@@ -1,6 +1,11 @@
 server {
-    listen 80;
-    server_name parking.titanpark.online 172.236.225.42;
+    server_name parking.titanpark.online;
+
+    # Handle Let's Encrypt ACME challenges
+    location /.well-known/acme-challenge/ {
+        root /var/www/html;
+        try_files $uri $uri/ =404;
+    }
 
     location / {
         proxy_pass http://127.0.0.1:8000;
@@ -9,4 +14,22 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
     }
+
+    listen [::]:443 ssl ipv6only=on; # managed by Certbot
+    listen 443 ssl; # managed by Certbot
+    ssl_certificate /etc/letsencrypt/live/parking.titanpark.online/fullchain.pem; # managed by Certbot
+    ssl_certificate_key /etc/letsencrypt/live/parking.titanpark.online/privkey.pem; # managed by Certbot
+    include /etc/letsencrypt/options-ssl-nginx.conf; # managed by Certbot
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem; # managed by Certbot
+
+}
+server {
+    if ($host = parking.titanpark.online) {
+        return 301 https://$host$request_uri;
+    } # managed by Certbot
+
+    listen 80;
+    listen [::]:80;
+    server_name parking.titanpark.online;
+    return 404; # managed by Certbot
 }

--- a/src/test_nginx_server.py
+++ b/src/test_nginx_server.py
@@ -1,0 +1,35 @@
+import requests
+
+class TestNginxHTTPS:
+  PARKING_DOMAIN = "parking.titanpark.online"  # Replace with your actual domain
+  HTTPS_URL = f"https://{PARKING_DOMAIN}/docs"
+  HTTP_URL = f"http://{PARKING_DOMAIN}/docs"
+
+  def test_TC_NS1(self):
+      """
+      Flutter requires an API to be hosted using HTTPS so we need to test that
+      our parking microservice API is using HTTPS or our flutter app won't be
+      able to make API requests to it.
+      """
+      try:
+        res = requests.get(self.HTTPS_URL, verify=True)
+        assert res.status_code == 200
+      except Exception as e:
+         raise AssertionError("Unable to connect to server using HTTPS.") from None
+
+  def test_TC_NS2(self):
+    """
+    Requests made to the server using HTTP should be redirected to use HTTPS.
+    """
+    res = requests.get(
+      self.HTTP_URL,
+      allow_redirects=False
+    )
+
+    # Check that server tried to redirect request
+    assert res.status_code in [301, 302, 307, 308], \
+      "Did not redirect from HTTP to HTTPS"
+
+    # Check that redirect location is using https
+    location = res.headers.get('Location', '')
+    assert 'https://' in location


### PR DESCRIPTION
I added HTTPS to the parking service server and documented some of the issues I had in issue #8. 

I modified the Nginx file to work with IPv6 and implemented test cases TC-NS1 and TC-NS2 to test that HTTPS is working correctly on the server. Both tests failed when I ran them before setting up HTTPS and they both passed after, so they seem to be working correctly.